### PR TITLE
fix typescript@next compilation problem

### DIFF
--- a/tsUnit/Scripts/tsUnit/tsUnit.ts
+++ b/tsUnit/Scripts/tsUnit/tsUnit.ts
@@ -267,7 +267,7 @@ class TestRunLimiter implements ITestRunLimiter {
     }
 
     private setRefreshOnLinksWithHash() {
-        var previousHandler = window.onhashchange;
+        var previousHandler = window.onhashchange.bind(window);
 
         window.onhashchange = function (ev: HashChangeEvent) {
             window.location.reload();

--- a/tsUnit/Scripts/tsUnit/tsUnit.ts
+++ b/tsUnit/Scripts/tsUnit/tsUnit.ts
@@ -267,13 +267,13 @@ class TestRunLimiter implements ITestRunLimiter {
     }
 
     private setRefreshOnLinksWithHash() {
-        var previousHandler = window.onhashchange.bind(window);
+        var previousHandler = window.onhashchange;
 
         window.onhashchange = function (ev: HashChangeEvent) {
             window.location.reload();
 
             if (typeof previousHandler === 'function') {
-                previousHandler(ev);
+                previousHandler.call(window, ev);
             }
         };
     }


### PR DESCRIPTION
With TypeScript 2.0 I am getting the following error message:

"'this' context of type 'void' is not assignable to method's 'this' of type 'Window'"

for line 276 of tsUnit.ts

The error might be a genuine problem if the previous onhashchange handler is making use of the fact that it's this is the window. On the other hand, the call in question is preceded by a window.location.reload(), so any problems might not be that relevant.

On the third hand, it would be way more convenient if the compiler didn't give that error message.

Fortunately, the fix appears to be quite simple.